### PR TITLE
feat: Add Docker Compose for Fintopio-bot with resource limits

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,37 @@
+# Node modules
+node_modules
+
+# Logs
+*.log
+
+# Environment files
+.env
+
+# Build output
+dist
+build
+
+# Test files and folders
+test
+tests
+coverage
+
+# Temporary files
+*.tmp
+*.swp
+
+# Git files
+.git
+.gitignore
+
+# Docker files
+Dockerfile
+.dockerignore
+
+# IDE files
+.vscode
+.idea
+
+# OS generated files
+.DS_Store
+Thumbs.db

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,13 @@
+FROM node:20.12-alpine3.19
+
+WORKDIR /usr/src/app
+
+COPY package*.json ./
+
+RUN npm install
+
+# Copy rest code
+COPY . .
+
+# Run the application with argument 2
+CMD ["npm", "start", "--", "2"]

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -1,0 +1,21 @@
+# Deprecated since new version of Docker-compose
+# version: '3'
+
+services:
+  app:
+    build: .
+    container_name: Fintopio-bot
+    volumes:
+      - .:/usr/src/app
+    
+    command: ["npm", "start", "--", "2"]
+
+    # Resource constraints
+    deploy:
+      resources:
+        limits:
+          # Limit CPU usage to a maximum of 0.25 cores (25% of a CPU core).
+          cpus: '0.25'  
+          
+          # Limit memory usage to a maximum of 100MB.
+          memory: 100M

--- a/src/tasks.js
+++ b/src/tasks.js
@@ -195,8 +195,8 @@ async function handleTasks(BEARERS) {
   const table = await createTable(BEARERS, fetchReferralData);
   console.log(table);
 
-  const mode = readlineSync.question(
-    'Do you want to run the bot one-time (1) or continuously (2)?\n\nEnter 1 or 2: '
+  const mode = process.argv[2] || readlineSync.question(
+  'Do you want to run the bot one-time (1) or continuously (2)?\n\nEnter 1 or 2: '
   );
 
   if (mode === '1') {


### PR DESCRIPTION
This PR introduces a Docker Compose configuration to simplify the deployment and management of the Fintopio-bot container. Key changes include:

- Added a `docker-compose.yml` file to manage the container lifecycle.
- Set resource limits:
  - CPU usage is capped at 0.25 cores.
  - Memory usage is limited to 100MB.
- Configured the app service to run `npm start` with the appropriate arguments.
  
These changes will help in optimizing the container's resource usage and simplify development and deployment workflows.